### PR TITLE
extension emits full error message

### DIFF
--- a/livelocals/__init__.py
+++ b/livelocals/__init__.py
@@ -131,9 +131,9 @@ class LiveLocals(object):
 
 
         def items(self):
-            for key, ref in self._vars.items():
+            for key, var in self._vars.items():
                 try:
-                    yield (key, ref.get_var())
+                    yield (key, var.get_var())
                 except NameError:
                     pass
 
@@ -158,9 +158,9 @@ class LiveLocals(object):
 
 
         def iteritems(self):
-            for key, ref in self._vars.iteritems():
+            for key, var in self._vars.iteritems():
                 try:
-                    yield (key, ref.get_var())
+                    yield (key, var.get_var())
                 except NameError:
                     pass
 
@@ -177,10 +177,10 @@ class LiveLocals(object):
 
 
     def update(self, mapping):
-        refs = self._vars
+        vars = self._vars
         for key, val in mapping.items():
-            if key in refs:
-                refs[key].set_var(val)
+            if key in vars:
+                vars[key].set_var(val)
 
 
     def setdefault(self, key, default=None):

--- a/livelocals/__init__.py
+++ b/livelocals/__init__.py
@@ -105,17 +105,7 @@ class LiveLocals(object):
 
 
     def __getitem__(self, key):
-        try:
-            return self._refs[key].get_ref()
-
-        except NameError as ne:
-            # TODO: make the extension do this on its own.
-            # Issue #6
-
-            msg = "name %r is not defined" % key
-            ne.message = msg
-            ne.args = (msg, )
-            raise
+        return self._vars[key].get_var()
 
 
     def __setitem__(self, key, value):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -135,5 +135,21 @@ class TestLiveLocals(TestCase):
         self.assertFalse(ll1 is ll2)
 
 
+    def test_name_error(self):
+
+        def make_inner():
+            x = 100
+            del x
+            return livelocals()
+
+        ll = make_inner()
+
+        try:
+            ll["x"]
+        except NameError as ne:
+            self.assertEqual(ne.args[0], "name 'x' is not defined")
+        else:
+            self.assertFalse(True)
+
 #
 # The end.


### PR DESCRIPTION
* some inconsistent naming
* updated the extension code to set the full ```NameError``` message for ```NULL``` vars
* no longer need to wrap ```__getitem__``` in a try
* added unittest to verify ```NameError``` is raised with the right message

Closes #6