### PR TITLE
optional default value in get_fast_var and get_cell_var

### DIFF
--- a/livelocals/__init__.py
+++ b/livelocals/__init__.py
@@ -140,10 +140,7 @@ def getvar(name, default=_raise_error, frame=None):
         return var.getvar()
 
     else:
-        try:
-            return var.getvar()
-        except NameError:
-            return default
+        return var.getvar(default)
 
 
 def setvar(name, value, frame=None):
@@ -379,8 +376,8 @@ class LiveLocals(object):
         """
 
         try:
-            return self._vars[key].getvar()
-        except (KeyError, NameError):
+            return self._vars[key].getvar(default)
+        except KeyError:
             return default
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -384,6 +384,7 @@ class TestLocalVar(TestCase):
 
         var.delvar()
         self.assertRaises(NameError, var.getvar)
+        self.assertEqual(var.getvar(321), 321)
 
         del var
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -389,7 +389,7 @@ class TestLocalVar(TestCase):
         del var
 
 
-    def test_getvar(self):
+    def test_getvar_fast(self):
 
         self.assertRaises(NameError, getvar, "cheddar")
         self.assertEqual(getvar("cheddar", 123), 123)
@@ -403,6 +403,28 @@ class TestLocalVar(TestCase):
         self.assertEqual(getvar("cheddar"), 200)
 
         del cheddar
+
+        self.assertRaises(NameError, getvar, "cheddar")
+        self.assertEqual(getvar("cheddar", 321), 321)
+
+
+    def test_getvar_cell(self):
+
+        def junk():
+            return cheddar
+
+        self.assertRaises(NameError, getvar, "cheddar")
+        self.assertEqual(getvar("cheddar", 123), 123)
+
+        cheddar = 100
+
+        self.assertEqual(getvar("cheddar"), 100)
+
+        cheddar = 200
+
+        self.assertEqual(getvar("cheddar"), 200)
+
+        delvar("cheddar")
 
         self.assertRaises(NameError, getvar, "cheddar")
         self.assertEqual(getvar("cheddar", 321), 321)


### PR DESCRIPTION
* adds an optional parameter for a default value to get_fast_var and get_cell_var, returned when they are NULL
* adopt code to use this default system over more manual methods
* unittests

Closes #10